### PR TITLE
Enhancement: ras_cli

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -8,6 +8,8 @@ source ~/.nvm/nvm.sh
 export IGN_PARTITION=$RAS_APP_NAME
 export ROS_DOMAIN_ID=2
 
+# include the ras_cli_setup.sh
+source $RAS_APP_PATH/scripts/ras_cli_setup.sh
 
 ras_app() { if [ -e /tmp/.RAS_RUN ]
     then

--- a/scripts/ras_cli_setup.sh
+++ b/scripts/ras_cli_setup.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/bash
+
+load_experiment() {
+    local exp_number=$1
+    echo "Loading experiment $exp_number"
+    ros2 service call /get_exepriment ras_interfaces/srv/LoadExp "{exepriment_id: '$exp_number', instruction_no: '', picked_object: ''}"
+}
+
+
+run_sim_robot() {
+    echo "running sim robot"
+    ros2 service call /test_experiment std_srvs/srv/SetBool "data: false"
+}
+
+run_real_robot() {
+    echo "running real robot"
+    ros2 action send_goal /execute_exp ras_interfaces/action/ExecuteExp {}
+}
+
+
+# register in bash configuration
+ras_cli() {
+    local command=$1
+    shift
+    case "$command" in
+        load_experiment)
+            load_experiment "$@"
+            ;;
+        run_sim_robot)
+            run_sim_robot
+            ;;
+        run_real_robot)
+            run_real_robot "$@"
+            ;;
+        -h|--help)
+            echo "Usage: ras_cli <command> [options]"
+            echo "Commands:"
+            echo "  load_experiment <exp_number>   Load the specified experiment"
+            echo "  run_sim_robot                Start the simulation robot for the specified experiment"
+            echo "  run_real_robot               Start the real robot for the specified experiment"
+            ;;
+        *)
+            echo "Unknown command: $command"
+            echo "Use -h or --help for usage information."
+            ;;
+    esac
+}
+
+# Enable autocomplete for ras_cli
+_complete_ras_cli() {
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="load_experiment run_sim_robot run_real_robot -h --help"
+
+    if [[ ${cur} == -* ]]; then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+}
+
+complete -F _complete_ras_cli ras_cli
+# Example usage
+# ras_cli load_experiment 1

--- a/scripts/ras_cli_setup.sh
+++ b/scripts/ras_cli_setup.sh
@@ -2,23 +2,26 @@
 
 load_experiment() {
     local exp_number=$1
+    if [ -z "$exp_number" ]; then
+        echo "Please provide a valid experiment number like"
+        echo "ras_cli load_experiment 1"
+        return 1
+    fi
     echo "Loading experiment $exp_number"
     ros2 service call /get_exepriment ras_interfaces/srv/LoadExp "{exepriment_id: '$exp_number', instruction_no: '', picked_object: ''}"
 }
 
-
 run_sim_robot() {
-    echo "running sim robot"
+    echo "Running simulation robot"
     ros2 service call /test_experiment std_srvs/srv/SetBool "data: false"
 }
 
 run_real_robot() {
-    echo "running real robot"
+    echo "Running real robot"
     ros2 action send_goal /execute_exp ras_interfaces/action/ExecuteExp {}
 }
 
-
-# register in bash configuration
+# Register in bash configuration
 ras_cli() {
     local command=$1
     shift
@@ -30,14 +33,14 @@ ras_cli() {
             run_sim_robot
             ;;
         run_real_robot)
-            run_real_robot "$@"
+            run_real_robot
             ;;
         -h|--help)
             echo "Usage: ras_cli <command> [options]"
             echo "Commands:"
             echo "  load_experiment <exp_number>   Load the specified experiment"
-            echo "  run_sim_robot                Start the simulation robot for the specified experiment"
-            echo "  run_real_robot               Start the real robot for the specified experiment"
+            echo "  run_sim_robot                  Start the simulation robot"
+            echo "  run_real_robot                 Start the real robot"
             ;;
         *)
             echo "Unknown command: $command"
@@ -46,20 +49,23 @@ ras_cli() {
     esac
 }
 
-# Enable autocomplete for ras_cli
-_complete_ras_cli() {
-    local cur prev opts
-    COMPREPLY=()
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="load_experiment run_sim_robot run_real_robot -h --help"
+# Enable bash completion for ras_cli commands
+_ras_cli_completion() {
+    local cur prev commands
+    COMPREPLY=()   # Array of completions
+    cur="${COMP_WORDS[COMP_CWORD]}"  # Current word being typed
+    prev="${COMP_WORDS[COMP_CWORD-1]}"  # Previous word
 
-    if [[ ${cur} == -* ]]; then
-        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
-        return 0
+    commands="load_experiment run_sim_robot run_real_robot"
+
+    # If the first argument is 'ras_cli', suggest 'load_experiment', 'run_sim_robot', and 'run_real_robot'
+    if [[ ${COMP_WORDS[0]} == "ras_cli" ]]; then
+        COMPREPLY=( $(compgen -W "$commands" -- "$cur") )
+    elif [[ $prev == "load_experiment" ]]; then
+        # If the previous word was 'load_experiment', suggest experiment numbers (e.g., 1, 2, 3, etc.)
+        COMPREPLY=( $(compgen -W "1 2 3 4 5" -- "$cur") )
     fi
 }
 
-complete -F _complete_ras_cli ras_cli
-# Example usage
-# ras_cli load_experiment 1
+# Register the completion function for 'ras_cli'
+complete -F _ras_cli_completion ras_cli


### PR DESCRIPTION
# PR Description

This PR introduces a Command-Line Interface (CLI) utility called `ras_cli`, designed for managing and interacting with robot experiments. It includes the following commands:

- **`load_experiment <exp_number>`**: Loads the specified experiment using the provided experiment number. This command is useful for preparing the system to run simulations or control robots.
  
- **`run_sim_robot`**: Starts a simulation robot for the specified experiment. This allows users to test the robot's performance and behavior in a virtual environment before interacting with real hardware.
  
- **`run_real_robot`**: Starts the real robot for the specified experiment. This command is used to execute the experiment in a real-world environment, using the actual robot hardware.

These commands provide an easy and structured way to run and manage experiments with simulation and real robot setups.